### PR TITLE
merge DEV-016-fix-and-and-add-backEnd-tests into MASTER

### DIFF
--- a/src/main/java/be/syntra/devshop/DevshopBack/repositories/ProductRepository.java
+++ b/src/main/java/be/syntra/devshop/DevshopBack/repositories/ProductRepository.java
@@ -4,10 +4,6 @@ import be.syntra.devshop.DevshopBack.entities.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
-
-    List<Product> findAll();
 }

--- a/src/test/java/be/syntra/devshop/DevshopBack/controllers/ProductControllerTest.java
+++ b/src/test/java/be/syntra/devshop/DevshopBack/controllers/ProductControllerTest.java
@@ -4,24 +4,26 @@ import be.syntra.devshop.DevshopBack.entities.Product;
 import be.syntra.devshop.DevshopBack.models.ProductDto;
 import be.syntra.devshop.DevshopBack.services.ProductServiceImpl;
 import be.syntra.devshop.DevshopBack.services.utilities.MapperUtility;
+import be.syntra.devshop.DevshopBack.testutilities.ProductUtils;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.List;
 
 import static be.syntra.devshop.DevshopBack.testutilities.GeneralUtils.asJsonString;
-import static be.syntra.devshop.DevshopBack.testutilities.ProductUtils.createProductDto;
-import static be.syntra.devshop.DevshopBack.testutilities.ProductUtils.createProductList;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.when;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.times;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ProductController.class)
 class ProductControllerTest {
@@ -33,38 +35,51 @@ class ProductControllerTest {
     private ProductServiceImpl productService;
 
     @MockBean
-    private ProductController productController;
-
-    @Mock
-    private ProductDto productDto;
-
-    @Mock
     private MapperUtility mapperUtility;
 
+
     @Test
-    void addProductTest() throws Exception {
-        // Given
-        ProductDto newProduct = createProductDto();
-        // When
-        when(productService.save(any(ProductDto.class))).thenReturn(newProduct);
-        // Then
-        mockMvc.perform(post("/products")
-                .content(asJsonString(newProduct))
-                .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+    void testRetrieveAllProductsEndpoint() throws Exception {
+        // given
+        List<Product> productList = ProductUtils.createDummyProductList();
+        Mockito.when(productService.findAll()).thenReturn(productList);
+        // when
+        ResultActions resultActions =
+                mockMvc.perform(
+                        get("/products")
+                );
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].name").value(equalTo("test")))
+                .andExpect(jsonPath("$[0].price").value(equalTo(55.99)))
+                .andExpect(jsonPath("$[1].name", is("product")))
+                .andExpect(jsonPath("$[1].price", is(110)));
+
+        Mockito.verify(productService,times(1)).findAll()   ;
     }
 
     @Test
-    void allProductsEndPointTest() throws Exception {
-        // Given
-        List<Product> products = createProductList();
-        ProductDto singleProduct = mapperUtility.convertToProductDto(products.get(0));
-        // When
-        when(productService.save(singleProduct)).thenReturn(singleProduct);
-        when(productService.findAll()).thenReturn(products);
-        // Then
-        mockMvc.perform(get("/products"))
-                .andExpect(status().isOk());
-    }
+    void createProductEndpoint() throws Exception {
+        // given
+        ProductDto productDtoDummy = ProductUtils.createProductDto();
+        // when
+        ResultActions resultActions =
+                mockMvc.perform(
+                        post("/products")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(productDtoDummy))
+                );
+        // then
+        resultActions
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.name").value(productDtoDummy.getName()))
+                .andExpect(jsonPath("$.price").value(1.00));
 
+        Mockito.verify(productService,times(1)).save(productDtoDummy);
+
+    }
 }

--- a/src/test/java/be/syntra/devshop/DevshopBack/controllers/TstRestControllerTest.java
+++ b/src/test/java/be/syntra/devshop/DevshopBack/controllers/TstRestControllerTest.java
@@ -5,10 +5,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(TstRestController.class)
 class TstRestControllerTest {
@@ -18,9 +18,16 @@ class TstRestControllerTest {
 
     @Test
     void displayTstString() throws Exception {
-        mockMvc.perform(get("/devshop/test"))
+        // given
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/devshop/test"));
+
+        // then
+        resultActions
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(content().string("DevShop"));
+                .andExpect(content().string("DevShop"))
+                .andExpect(jsonPath("$").value("DevShop"));
     }
 }

--- a/src/test/java/be/syntra/devshop/DevshopBack/services/ProductServiceTest.java
+++ b/src/test/java/be/syntra/devshop/DevshopBack/services/ProductServiceTest.java
@@ -1,34 +1,62 @@
 package be.syntra.devshop.DevshopBack.services;
 
 import be.syntra.devshop.DevshopBack.entities.Product;
+import be.syntra.devshop.DevshopBack.models.ProductDto;
+import be.syntra.devshop.DevshopBack.repositories.ProductRepository;
+import be.syntra.devshop.DevshopBack.services.utilities.MapperUtility;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.MockMvc;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import java.util.List;
 
+import static be.syntra.devshop.DevshopBack.testutilities.ProductUtils.createProductDto;
 import static be.syntra.devshop.DevshopBack.testutilities.ProductUtils.createProductList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
-@WebMvcTest(ProductServiceImpl.class)
 public class ProductServiceTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+    @Mock
+    private MapperUtility mapperUtility;
 
-    @MockBean
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
     private ProductServiceImpl productService;
+
+    @BeforeEach
+    public void init(){
+        MockitoAnnotations.initMocks(this);
+    }
 
     @Test
     void getAllProductsTest() {
-        // Given
-        List<Product> products = createProductList();
-        // When
-        when(productService.findAll()).thenReturn(products);
-        // Then
-        assertThat(productService.findAll().size()).isEqualTo(products.size());
+        // given
+        List<Product> dummyProducts = createProductList();
+        when(productRepository.findAll()).thenReturn(dummyProducts);
+
+        // when
+        List<Product> resultProductList = productService.findAll();
+
+        // then
+        assertEquals(resultProductList,dummyProducts);
+        verify(productRepository,times(1)).findAll();
+    }
+
+    @Test
+    void saveProductTest(){
+        // given
+        ProductDto dummyDto = createProductDto();
+
+        // when
+        ProductDto resultProductDto = productService.save(dummyDto);
+
+        // then
+        assertEquals(dummyDto,resultProductDto);
+        verify(productRepository,times(1)).save(any());
     }
 }

--- a/src/test/java/be/syntra/devshop/DevshopBack/services/utilities/MapperUtilityTest.java
+++ b/src/test/java/be/syntra/devshop/DevshopBack/services/utilities/MapperUtilityTest.java
@@ -1,0 +1,62 @@
+package be.syntra.devshop.DevshopBack.services.utilities;
+
+import be.syntra.devshop.DevshopBack.entities.Product;
+import be.syntra.devshop.DevshopBack.models.ProductDto;
+import be.syntra.devshop.DevshopBack.testutilities.ProductUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MapperUtilityTest {
+
+    MapperUtility mapperUtility = new MapperUtility();
+
+    @Test
+    void convertToProduct() {
+        // given
+        Product product = ProductUtils.createProduct();
+        ProductDto productDto = ProductUtils.createProductDto();
+
+        // when
+        Product mappedProduct = mapperUtility.convertToProduct(productDto);
+
+        // then
+        assertEquals(mappedProduct.getClass(),Product.class);
+        assertEquals(mappedProduct.getName(),product.getName());
+        assertEquals(mappedProduct.getPrice(),product.getPrice());
+    }
+
+    @Test
+    void convertToProductDto() {
+        // given
+        Product product = ProductUtils.createProductWithId();
+        ProductDto productDto = ProductUtils.createProductDto();
+
+        // when
+        ProductDto mappedProductDto = mapperUtility.convertToProductDto(product);
+
+        // then
+        assertEquals(mappedProductDto.getClass(),ProductDto.class);
+        assertEquals(mappedProductDto.getName(),productDto.getName());
+        assertEquals(mappedProductDto.getPrice(),productDto.getPrice());
+    }
+
+    @Test
+    void convertListToDtos() {
+        // given
+        List<Product> dummyProductList = ProductUtils.createDummyProductList();
+
+        // when
+        List<ProductDto> mappedToProductDtoList = mapperUtility.convertListToDtos(dummyProductList);
+
+        // then
+        assertEquals(mappedToProductDtoList.get(0).getClass(),ProductDto.class);
+        assertEquals(dummyProductList.size(),mappedToProductDtoList.size());
+        assertEquals(mappedToProductDtoList.get(0).getName(),dummyProductList.get(0).getName());
+        assertEquals(mappedToProductDtoList.get(1).getName(),dummyProductList.get(1).getName());
+        assertEquals(mappedToProductDtoList.get(0).getPrice(),dummyProductList.get(0).getPrice());
+        assertEquals(mappedToProductDtoList.get(1).getPrice(),dummyProductList.get(1).getPrice());
+    }
+}

--- a/src/test/java/be/syntra/devshop/DevshopBack/testutilities/ProductUtils.java
+++ b/src/test/java/be/syntra/devshop/DevshopBack/testutilities/ProductUtils.java
@@ -4,6 +4,7 @@ import be.syntra.devshop.DevshopBack.entities.Product;
 import be.syntra.devshop.DevshopBack.models.ProductDto;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -23,11 +24,28 @@ public class ProductUtils {
                 .build();
     }
 
+    public static Product createProductWithId() {
+        return Product.builder()
+                .id(1L)
+                .name("post-its")
+                .price(BigDecimal.valueOf(1.00))
+                .build();
+    }
+
     public static List<Product> createProductList() {
         List<Product> products = new LinkedList<>();
         for (int i = 0; i < 3; i++) {
             products.add(createProduct());
         }
         return products;
+    }
+
+    public static List<Product> createDummyProductList() {
+        Product product1 = Product.builder().name("test").price(new BigDecimal("55.99")).build();
+        Product product2 = Product.builder().name("product").price(new BigDecimal("110")).build();
+        List<Product> productList = new ArrayList<>();
+        productList.add(product1);
+        productList.add(product2);
+        return productList;
     }
 }


### PR DESCRIPTION
remove findAll() from ProductRepository because it is not overridden and so its still implemented in the JpaRepository itself
clean up, and rearrange all tests
add tests for mapper